### PR TITLE
Allow completion banner display from Game Center.

### DIFF
--- a/extension/gamecenter/GameCenter.hx
+++ b/extension/gamecenter/GameCenter.hx
@@ -112,13 +112,14 @@ class GameCenter {
 
         @param achievementID The Achievement ID.
         @param percentComplete The range of legal values is between 0.0 and 100.0, inclusive.
+        @param showCompletionBanner Indicates if GameCenter should display the completion banner for this achievement if completed.
     **/
-	public static function reportAchievement (achievementID:String, percentComplete:Float):Void {
+	public static function reportAchievement (achievementID:String, percentComplete:Float, showCompletionBanner:Bool=true):Void {
 		
 		initialize ();
 		
 		#if ios
-		gamecenter_reportachievement (achievementID, percentComplete);
+		gamecenter_reportachievement (achievementID, percentComplete, showCompletionBanner);
 		#end
 		
 	}
@@ -206,7 +207,7 @@ class GameCenter {
 	private static var gamecenter_showleaderboard = Lib.load ("gamecenter", "gamecenter_showleaderboard", 1);
 	private static var gamecenter_showachievements = Lib.load ("gamecenter", "gamecenter_showachievements", 0);
 	private static var gamecenter_reportscore = Lib.load ("gamecenter", "gamecenter_reportscore", 2);
-	private static var gamecenter_reportachievement = Lib.load ("gamecenter", "gamecenter_reportachievement", 2);
+	private static var gamecenter_reportachievement = Lib.load ("gamecenter", "gamecenter_reportachievement", 3);
 	private static var gamecenter_resetachievements = Lib.load ("gamecenter", "gamecenter_resetachievements", 0);
 	#end
 	

--- a/project/common/ExternalInterface.cpp
+++ b/project/common/ExternalInterface.cpp
@@ -123,14 +123,14 @@ static value gamecenter_reportscore(value categoryID, value score)
 DEFINE_PRIM(gamecenter_reportscore, 2);
 
 
-static value gamecenter_reportachievement(value achievementID, value percent)
+static value gamecenter_reportachievement(value achievementID, value percent, value showCompletionBanner)
 {
 	#ifdef IPHONE
-	reportAchievement(val_string(achievementID),val_float(percent));
+	reportAchievement(val_string(achievementID),val_float(percent),val_bool(showCompletionBanner));
 	#endif
 	return alloc_null();
 }
-DEFINE_PRIM(gamecenter_reportachievement, 2);
+DEFINE_PRIM(gamecenter_reportachievement, 3);
 
 
 static value gamecenter_resetachievements()

--- a/project/include/GameCenter.h
+++ b/project/include/GameCenter.h
@@ -20,7 +20,7 @@ namespace gamecenter
     //Achievements
     void showAchievements();
     void resetAchievements();
-    void reportAchievement(const char* achievementID, float percent);
+    void reportAchievement(const char* achievementID, float percent, bool showCompletionBanner);
     
     //Other
     void registerForAuthenticationNotification();

--- a/project/iphone/GameCenter.mm
+++ b/project/iphone/GameCenter.mm
@@ -80,7 +80,7 @@ namespace gamecenter
     //Achievements
     void showAchievements();
     void resetAchievements();
-    void reportAchievement(const char* achievementID, float percent);
+    void reportAchievement(const char* achievementID, float percent, bool showCompletionBanner);
     
     //Callbacks
     void registerForAuthenticationNotification();
@@ -304,7 +304,7 @@ namespace gamecenter
 	 * \param achievementID The Achievement ID.
 	 * \param percentComplete The range of legal values is between 0.0 and 100.0, inclusive.
 	 */
-    void reportAchievement(const char* achievementID, float percentComplete)
+    void reportAchievement(const char* achievementID, float percentComplete, bool showCompletionBanner)
     {
         NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
 		NSString* strAchievement = [[NSString alloc] initWithUTF8String:achievementID];
@@ -319,6 +319,7 @@ namespace gamecenter
         	}*/
         	
 			achievement.percentComplete = percentComplete;    
+			achievement.showsCompletionBanner = showCompletionBanner;
 			[achievement reportAchievementWithCompletionHandler:^(NSError *error)
             {
 				if(error != nil)


### PR DESCRIPTION
And add an optional parameter to disable it when calling reportAchievement function in case someone want's to avoid the completion banner.