### PR TITLE
Critical chrash & Funcional fix

### DIFF
--- a/extension/gamecenter/GameCenter.hx
+++ b/extension/gamecenter/GameCenter.hx
@@ -11,178 +11,136 @@ import flash.Lib;
 
 class GameCenter {
 	
-	
+	// Static vars
+
 	public static var available (get, null):Bool;
-	
 	private static var dispatcher = new EventDispatcher ();
 	private static var initialized = false;
+
 	
-	
+	// Static methods
+
 	public static function addEventListener (type:String, listener:Dynamic, useCapture:Bool = false, priority:Int = 0, useWeakReference:Bool = false):Void {
-		
 		dispatcher.addEventListener (type, listener, useCapture, priority, useWeakReference);
-		
 	}
+
 	
 	public static function removeEventListener (type:String, listener:Dynamic):Void {
-		
 		dispatcher.removeEventListener (type, listener);
-		
 	}
 	
+
 	public static function authenticate ():Void {
-		
-		initialize ();
-		
 		#if ios
+		initialize ();
 		Lib.pause ();
 		gamecenter_authenticate ();
 		#end
-		
 	}
 	
-	
+
 	public static function dispatchEvent (event:Event):Bool {
-		
 		return dispatcher.dispatchEvent (event);
-		
 	}
 	
 	
 	public static function hasEventListener (type:String):Bool {
-		
 		return dispatcher.hasEventListener (type);
-		
 	}
-	
+
 	
 	private static function initialize ():Void {
-		
 		if (!initialized) {
-			
 			#if ios
 			gamecenter_set_event_handle (notifyListeners);
 			gamecenter_initialize ();
 			#end
-			
 			initialized = true;
-			
 		}
-		
 	}
-	
+
 	
 	public static function getPlayerName ():String {
-		
-		initialize ();
-		
 		#if ios
+		initialize ();
 		return gamecenter_playername ();
 		#else
 		return null;
 		#end
-		
 	}
 	
-	
+
 	public static function getPlayerID ():String {
-		
-		initialize ();
-		
 		#if ios
+		initialize ();
 		return gamecenter_playerid ();
 		#else
 		return null;
 		#end
-		
 	}
-	
+
 	
 	private static function notifyListeners (inEvent:Dynamic) {
-		
 		#if ios
-		
 		Lib.resume ();
-		
 		var type = Std.string (Reflect.field (inEvent, "type"));
 		var data = Std.string (Reflect.field (inEvent, "data"));
 		dispatcher.dispatchEvent(new GameCenterEvent(type, data));
-		
 		#end
-		
 	}
 	
-	/**
-        Reports changed in achievement completion.
 
-        @param achievementID The Achievement ID.
-        @param percentComplete The range of legal values is between 0.0 and 100.0, inclusive.
-        @param showCompletionBanner Indicates if GameCenter should display the completion banner for this achievement if completed.
-    **/
+	/**
+		Reports changed in achievement completion.
+
+		@param achievementID The Achievement ID.
+		@param percentComplete The range of legal values is between 0.0 and 100.0, inclusive.
+		@param showCompletionBanner Indicates if GameCenter should display the completion banner for this achievement if completed.
+	**/
 	public static function reportAchievement (achievementID:String, percentComplete:Float, showCompletionBanner:Bool=true):Void {
-		
-		initialize ();
-		
 		#if ios
+		initialize ();
 		gamecenter_reportachievement (achievementID, percentComplete, showCompletionBanner);
 		#end
-		
 	}
 	
-	
+
 	public static function reportScore (categoryID:String, score:Int):Void {
-		
-		initialize ();
-		
 		#if ios
+		initialize ();
 		gamecenter_reportscore (categoryID, score);
 		#end
-		
 	}
 	
-	
+
 	public static function resetAchievements ():Void {
-		
-		initialize ();
-		
 		#if ios
+		initialize ();
 		gamecenter_resetachievements ();
 		#end
-		
 	}
 	
-	
+
 	public static function showAchievements ():Void {
-		
-		initialize ();
-		
 		#if ios
+		initialize ();
 		//Lib.pause ();
 		gamecenter_showachievements ();
 		#end
-		
 	}
 	
-	
+
 	public static function showLeaderboard (categoryID:String):Void {
-		
-		initialize ();
-		
 		#if ios
-//		Lib.pause ();
+		initialize ();
+		//Lib.pause ();
 		gamecenter_showleaderboard (categoryID);
 		#end
-		
 	}
 	
-	
-	
-	
+
 	// Get & Set Methods
-	
-	
-	
-	
+
 	private static function get_available ():Bool {
 		
 		#if ios
@@ -193,14 +151,9 @@ class GameCenter {
 		
 	}
 	
-	
-	
-	
+
 	// Native Methods
-	
-	
-	
-	
+
 	#if ios
 	private static var gamecenter_set_event_handle = Lib.load ("gamecenter", "gamecenter_set_event_handle", 1);
 	private static var gamecenter_initialize = Lib.load ("gamecenter", "gamecenter_initialize", 0);
@@ -215,6 +168,5 @@ class GameCenter {
 	private static var gamecenter_reportachievement = Lib.load ("gamecenter", "gamecenter_reportachievement", 3);
 	private static var gamecenter_resetachievements = Lib.load ("gamecenter", "gamecenter_resetachievements", 0);
 	#end
-	
 	
 }

--- a/project/iphone/GameCenter.mm
+++ b/project/iphone/GameCenter.mm
@@ -162,7 +162,12 @@ namespace gamecenter
 					registerForAuthenticationNotification();
 					sendGameCenterEvent(AUTH_SUCCESS, "");
 	            }
-
+	            else if ( viewcontroller != nil )
+				{
+					NSLog(@"Game Center: User was not logged in. Show Login Screen.");
+					UIViewController *glView2 = [[[UIApplication sharedApplication] keyWindow] rootViewController];
+					[glView2 presentModalViewController: viewcontroller animated : NO];
+				}
 	            else if(error != nil)
                 {
 					NSLog(@"Game Center: Error occurred authenticating-");

--- a/project/iphone/GameCenter.mm
+++ b/project/iphone/GameCenter.mm
@@ -196,7 +196,7 @@ namespace gamecenter
         
         else
         {
-            return "";
+            return NULL;
         }
     }
     
@@ -211,7 +211,7 @@ namespace gamecenter
         
         else
         {
-            return "";
+            return NULL;
         }
     }
     

--- a/project/iphone/GameCenter.mm
+++ b/project/iphone/GameCenter.mm
@@ -7,9 +7,7 @@ extern "C" void sendGameCenterEvent(const char* event, const char* data);
 
 typedef void (*FunctionType)();
 
-@interface GKViewDelegate : NSObject <GKAchievementViewControllerDelegate,GKLeaderboardViewControllerDelegate>
-{
-}
+@interface GKViewDelegate : NSObject <GKAchievementViewControllerDelegate,GKLeaderboardViewControllerDelegate> { }
 
 - (void)achievementViewControllerDidFinish:(GKAchievementViewController*)viewController;
 - (void)leaderboardViewControllerDidFinish:(GKLeaderboardViewController*)viewController;
@@ -24,30 +22,26 @@ typedef void (*FunctionType)();
 @synthesize onAchievementFinished;
 @synthesize onLeaderboardFinished;
 
-- (id)init 
-{
-    self = [super init];
-    return self;
+- (id)init {
+	self = [super init];
+	return self;
 }
 
-- (void)dealloc 
-{
-    [super dealloc];
+- (void)dealloc {
+	[super dealloc];
 }
 
 UIViewController *glView2;
 
-- (void)achievementViewControllerDidFinish:(GKAchievementViewController*)viewController
-{
-    [viewController dismissModalViewControllerAnimated:YES];
+- (void)achievementViewControllerDidFinish:(GKAchievementViewController*)viewController {
+	[viewController dismissModalViewControllerAnimated:YES];
 	[viewController.view.superview removeFromSuperview];
 	[viewController release];
 	onAchievementFinished();
 }
 
-- (void)leaderboardViewControllerDidFinish:(GKLeaderboardViewController*)viewController
-{
-    [viewController dismissModalViewControllerAnimated:YES];
+- (void)leaderboardViewControllerDidFinish:(GKLeaderboardViewController*)viewController {
+	[viewController dismissModalViewControllerAnimated:YES];
 	[viewController.view.superview removeFromSuperview];
 	[viewController release];
 	onLeaderboardFinished();
@@ -57,36 +51,34 @@ UIViewController *glView2;
 
 
 
-namespace gamecenter 
-{
-    static int isInitialized = 0;
-    GKViewDelegate* viewDelegate;
-    
-    //---
-    
-    //User
+namespace gamecenter {
+
+	static int isInitialized = 0;
+	GKViewDelegate* viewDelegate;
+	
+	//User
 	void initializeGameCenter();
-    bool isGameCenterAvailable();
+	bool isGameCenterAvailable();
 	bool isUserAuthenticated();
-    void authenticateLocalUser();
-    
-    const char* getPlayerName();
-    const char* getPlayerID();
-    
-    //Leaderboards
-    void showLeaderboard(const char* categoryID);
-    void reportScore(const char* categoryID, int score);
-    
-    //Achievements
-    void showAchievements();
-    void resetAchievements();
-    void reportAchievement(const char* achievementID, float percent, bool showCompletionBanner);
-    
-    //Callbacks
-    void registerForAuthenticationNotification();
-    static void authenticationChanged(CFNotificationCenterRef center, void* observer, CFStringRef name, const void* object, CFDictionaryRef userInfo);
-    
-    void achievementViewDismissed();
+	void authenticateLocalUser();
+	
+	const char* getPlayerName();
+	const char* getPlayerID();
+	
+	//Leaderboards
+	void showLeaderboard(const char* categoryID);
+	void reportScore(const char* categoryID, int score);
+	
+	//Achievements
+	void showAchievements();
+	void resetAchievements();
+	void reportAchievement(const char* achievementID, float percent, bool showCompletionBanner);
+	
+	//Callbacks
+	void registerForAuthenticationNotification();
+	static void authenticationChanged(CFNotificationCenterRef center, void* observer, CFStringRef name, const void* object, CFDictionaryRef userInfo);
+	
+	void achievementViewDismissed();
 	void leaderboardViewDismissed();
 
 	//Events
@@ -99,302 +91,229 @@ namespace gamecenter
 	static const char* ACHIEVEMENT_FAILURE = "achievementFailure";
 	static const char* ACHIEVEMENT_RESET_SUCCESS = "achievementResetSuccess";
 	static const char* ACHIEVEMENT_RESET_FAILURE = "achievementResetFailure";
-    
-    //---
-    
-    //USER
-    
-	void initializeGameCenter() 
-    {
-	    if(isInitialized == 1)
-        {
+	
+	//USER
+	
+	void initializeGameCenter() {
+		if(isInitialized == 1) {
 			return;
 		}
-        
-		if(isGameCenterAvailable())
-        {
-            viewDelegate = [[GKViewDelegate alloc] init];
+		
+		if(isGameCenterAvailable()) {
+			viewDelegate = [[GKViewDelegate alloc] init];
 			viewDelegate.onAchievementFinished = &achievementViewDismissed;
 			viewDelegate.onLeaderboardFinished = &leaderboardViewDismissed;
-            
+			
 			isInitialized = 1;
-            authenticateLocalUser();
+			authenticateLocalUser();
 		}
-    }
-    
-    bool isGameCenterAvailable()
-    {
+	}
+	
+	bool isGameCenterAvailable() {
 		// check for presence of GKLocalPlayer API
 		Class gcClass = (NSClassFromString(@"GKLocalPlayer"));
 		
-		// check if the device is running iOS 4.1 or later  
-		NSString* reqSysVer = @"4.1";   
-		NSString* currSysVer = [[UIDevice currentDevice] systemVersion];   
-		BOOL osVersionSupported = ([currSysVer compare:reqSysVer options:NSNumericSearch] != NSOrderedAscending);   
-		
+		// check if the device is running iOS 4.1 or later
+		NSString* reqSysVer = @"4.1";
+		NSString* currSysVer = [[UIDevice currentDevice] systemVersion];
+		BOOL osVersionSupported = ([currSysVer compare:reqSysVer options:NSNumericSearch] != NSOrderedAscending);
 		return (gcClass && osVersionSupported);
 	}
-    
-    bool isUserAuthenticated()
-    {
+	
+	bool isUserAuthenticated() {
 		return ([GKLocalPlayer localPlayer].isAuthenticated);
 	}
-    
-    void authenticateLocalUser() 
-    {
-        if(!isGameCenterAvailable())
-        {
+	
+	void authenticateLocalUser() {
+		if(!isGameCenterAvailable()) {
 			NSLog(@"Game Center: is not available");
 			return;
 		}
 		
 		NSLog(@"Authenticating local user...");
-		if ([GKLocalPlayer localPlayer].authenticated == NO)
-		{
+		if ([GKLocalPlayer localPlayer].authenticated == NO) {
 
-	        GKLocalPlayer *localPlayer = [GKLocalPlayer localPlayer];
-	        //[localPlayer authenticateWithCompletionHandler:^(NSError *error) { OLD CODE!
-	        [localPlayer setAuthenticateHandler:(^(UIViewController* viewcontroller, NSError *error)
-	        {
-	            if(localPlayer.isAuthenticated)
-	            {
+			GKLocalPlayer *localPlayer = [GKLocalPlayer localPlayer];
+			[localPlayer setAuthenticateHandler:(^(UIViewController* viewcontroller, NSError *error) {
+
+				if(localPlayer.isAuthenticated) {
 					NSLog(@"Game Center: You are logged in to game center.");
 					registerForAuthenticationNotification();
 					sendGameCenterEvent(AUTH_SUCCESS, "");
-	            }
-	            else if ( viewcontroller != nil )
-				{
+				} else if ( viewcontroller != nil ) {
 					NSLog(@"Game Center: User was not logged in. Show Login Screen.");
 					UIViewController *glView2 = [[[UIApplication sharedApplication] keyWindow] rootViewController];
 					[glView2 presentModalViewController: viewcontroller animated : NO];
-				}
-	            else if(error != nil)
-                {
+				} else if(error != nil) {
 					NSLog(@"Game Center: Error occurred authenticating-");
 					NSLog(@"  %@", [error localizedDescription]);
 					NSString* errorDescription = [error localizedDescription];
 					sendGameCenterEvent(AUTH_FAILURE, [errorDescription UTF8String]);
-	            }
-	        })];
-	    }
+				}
 
-	    else
-	    {
-	    	NSLog(@"Already authenticated!");
+			})];
+
+		} else {
+			NSLog(@"Already authenticated!");
 			sendGameCenterEvent(AUTH_ALREADY, "");
 		}
 	}
-    
-    const char* getPlayerName()
-    {
-        GKLocalPlayer* localPlayer = [GKLocalPlayer localPlayer];
-        
-        if(localPlayer.isAuthenticated)
-        {
-            return [localPlayer.alias cStringUsingEncoding:NSUTF8StringEncoding];
-        }
-        
-        else
-        {
-            return NULL;
-        }
-    }
-    
-    const char* getPlayerID()
-    {
-        GKLocalPlayer* localPlayer = [GKLocalPlayer localPlayer];
-        
-        if(localPlayer.isAuthenticated)
-        {
-            return [localPlayer.playerID cStringUsingEncoding:NSUTF8StringEncoding];
-        }
-        
-        else
-        {
-            return NULL;
-        }
-    }
-    
-    //LEADERBOARDS
-    
-    void showLeaderboard(const char* categoryID)
-    {
-        NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
+	
+	const char* getPlayerName() {
+		GKLocalPlayer* localPlayer = [GKLocalPlayer localPlayer];
+		
+		if(localPlayer.isAuthenticated) {
+			return [localPlayer.alias cStringUsingEncoding:NSUTF8StringEncoding];
+		} else {
+			return NULL;
+		}
+	}
+	
+	const char* getPlayerID() {
+		GKLocalPlayer* localPlayer = [GKLocalPlayer localPlayer];
+		
+		if(localPlayer.isAuthenticated) {
+			return [localPlayer.playerID cStringUsingEncoding:NSUTF8StringEncoding];
+		} else {
+			return NULL;
+		}
+	}
+	
+	//LEADERBOARDS
+	
+	void showLeaderboard(const char* categoryID) {
+		NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
 		NSString* strCategory = [[NSString alloc] initWithUTF8String:categoryID];
 		
 		UIWindow* window = [UIApplication sharedApplication].keyWindow;
-		GKLeaderboardViewController *leaderboardController = [[GKLeaderboardViewController alloc] init];  
+		GKLeaderboardViewController *leaderboardController = [[GKLeaderboardViewController alloc] init];
 		
-        if(leaderboardController != nil) 
-        {
+		if(leaderboardController != nil) {
 			leaderboardController.category = strCategory;
 			leaderboardController.leaderboardDelegate = viewDelegate;
-            UIViewController *glView2 = [[[UIApplication sharedApplication] keyWindow] rootViewController];
-            [glView2 presentModalViewController:leaderboardController animated: NO];
+			UIViewController *glView2 = [[[UIApplication sharedApplication] keyWindow] rootViewController];
+			[glView2 presentModalViewController:leaderboardController animated: NO];
 		}
 		
 		[strCategory release];
 		[pool drain];
-    }
-    
-    void reportScore(const char* categoryID, int score)
-    {
-        NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
+	}
+	
+	void reportScore(const char* categoryID, int score) {
+		NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
 		NSString* strCategory = [[NSString alloc] initWithUTF8String:categoryID];
 		GKScore* scoreReporter = [[[GKScore alloc] initWithCategory:strCategory] autorelease];
-        
-		if(scoreReporter)
-        {
+		
+		if(scoreReporter) {
 			scoreReporter.value = score;
-			
-			[scoreReporter reportScoreWithCompletionHandler:^(NSError *error) 
-            {   
-				if(error != nil)
-                {
+			[scoreReporter reportScoreWithCompletionHandler:^(NSError *error) {
+				if(error != nil) {
 					NSLog(@"Game Center: Error occurred reporting score-");
 					NSLog(@"  %@", [error userInfo]);
 					sendGameCenterEvent(SCORE_FAILURE, categoryID);
-				}
-                
-                else
-                {
+				} else {
 					NSLog(@"Game Center: Score was successfully sent");
 					sendGameCenterEvent(SCORE_SUCCESS, categoryID);
 				}
-			}];   
+			}];
 		}
-        
+		
 		[strCategory release];
 		[pool drain];
-    }
-    
-    //ACHIEVEMENTS
-    
-    void showAchievements()
-    {
-        NSLog(@"Game Center: Show Achievements");
+	}
+	
+	//ACHIEVEMENTS
+	
+	void showAchievements() {
+		NSLog(@"Game Center: Show Achievements");
 		UIWindow* window = [UIApplication sharedApplication].keyWindow;
 		GKAchievementViewController* achievements = [[GKAchievementViewController alloc] init]; 
-        
-		if(achievements != nil)
-        {
+		
+		if(achievements != nil) {
 			achievements.achievementDelegate = viewDelegate;
-            UIViewController *glView2 = [[[UIApplication sharedApplication] keyWindow] rootViewController];
-            [glView2 presentModalViewController: achievements animated: NO];
-            			//dispatchHaxeEvent(ACHIEVEMENTS_VIEW_OPENED);
+			UIViewController *glView2 = [[[UIApplication sharedApplication] keyWindow] rootViewController];
+			[glView2 presentModalViewController: achievements animated: NO];
 		}
-    }
-    
-    void resetAchievements()
-    {
-        [GKAchievement resetAchievementsWithCompletionHandler:^(NSError *error)
-        {
-            if(error != nil)
-            {
-                NSLog(@"  %@", [error userInfo]);
-                sendGameCenterEvent(ACHIEVEMENT_RESET_FAILURE, "");
-            }
-            
-            else
-            {
-                 sendGameCenterEvent(ACHIEVEMENT_RESET_SUCCESS, "");
-            }
-        }];
-    }
-    
-    /*!
+	}
+	
+	void resetAchievements() {
+		[GKAchievement resetAchievementsWithCompletionHandler:^(NSError *error) {
+			if(error != nil) {
+				NSLog(@"  %@", [error userInfo]);
+				sendGameCenterEvent(ACHIEVEMENT_RESET_FAILURE, "");
+			} else {
+				 sendGameCenterEvent(ACHIEVEMENT_RESET_SUCCESS, "");
+			}
+		}];
+	}
+	
+	/*!
 	 * Reports changed in achievement completion.
 	 *
 	 * \param achievementID The Achievement ID.
 	 * \param percentComplete The range of legal values is between 0.0 and 100.0, inclusive.
 	 */
-    void reportAchievement(const char* achievementID, float percentComplete, bool showCompletionBanner)
-    {
-        NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
+	void reportAchievement(const char* achievementID, float percentComplete, bool showCompletionBanner) {
+		NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
 		NSString* strAchievement = [[NSString alloc] initWithUTF8String:achievementID];
 		NSLog(@"Game Center: Report Achievements");
-    	NSLog(@"  %@", strAchievement);
+		NSLog(@"  %@", strAchievement);
 		GKAchievement* achievement = [[[GKAchievement alloc] initWithIdentifier:strAchievement] autorelease];
-		if(achievement)
-        {
-        	/*if(percentComplete >= 100)
-        	{
-        		achievement.showsCompletionBanner = YES;
-        	}*/
-        	
-			achievement.percentComplete = percentComplete;    
+		if(achievement) {
+			achievement.percentComplete = percentComplete;	
 			achievement.showsCompletionBanner = showCompletionBanner;
-			[achievement reportAchievementWithCompletionHandler:^(NSError *error)
-            {
-				if(error != nil)
-                {
+			[achievement reportAchievementWithCompletionHandler:^(NSError *error) {
+				if(error != nil) {
 					NSLog(@"Game Center: Error occurred reporting achievement-");
 					NSLog(@"  %@", [error userInfo]);
 					sendGameCenterEvent(ACHIEVEMENT_FAILURE, achievementID);
-				}
-                
-                else
-                {
+				} else {
 					NSLog(@"Game Center: Achievement report successfully sent");
 					sendGameCenterEvent(ACHIEVEMENT_SUCCESS, achievementID);
 				}
-                
 			}];
-		}
-        
-        else 
-        {
+		} else {
 			sendGameCenterEvent(ACHIEVEMENT_FAILURE, achievementID);
 		}
 		
 		[strAchievement release];
 		[pool drain];
-    }
-    
-    //CALLBACKS
-
-    void registerForAuthenticationNotification()
-    {
-		// TODO: need to REMOVE OBSERVER on dispose
-		CFNotificationCenterAddObserver
-		(
-        	CFNotificationCenterGetLocalCenter(),
-         	NULL,
-         	&authenticationChanged,
-         	(CFStringRef)GKPlayerAuthenticationDidChangeNotificationName,
-         	NULL,
-         	CFNotificationSuspensionBehaviorDeliverImmediately
-        );
 	}
-    
-    void authenticationChanged(CFNotificationCenterRef center, void* observer, CFStringRef name, const void* object, CFDictionaryRef userInfo)
-    {
-		if(!isGameCenterAvailable())
-        {
+	
+	//CALLBACKS
+
+	void registerForAuthenticationNotification() {
+		// TODO: need to REMOVE OBSERVER on dispose
+		CFNotificationCenterAddObserver (
+			CFNotificationCenterGetLocalCenter(),
+		 	NULL,
+		 	&authenticationChanged,
+		 	(CFStringRef)GKPlayerAuthenticationDidChangeNotificationName,
+		 	NULL,
+		 	CFNotificationSuspensionBehaviorDeliverImmediately
+		);
+	}
+	
+	void authenticationChanged(CFNotificationCenterRef center, void* observer, CFStringRef name, const void* object, CFDictionaryRef userInfo) {
+		if(!isGameCenterAvailable()) {
 			NSLog(@"Game Center: is not available");
 			return;
 		}
 		
-		if([GKLocalPlayer localPlayer].isAuthenticated)
-        {      
+		if([GKLocalPlayer localPlayer].isAuthenticated) {
 			NSLog(@"Game Center: You are logged in to game center.");
 			sendGameCenterEvent(AUTH_SUCCESS, "");
-		}
-        
-        else
-        {
+		} else {
 			NSLog(@"Game Center: You are NOT logged in to game center.");
 			sendGameCenterEvent(AUTH_FAILURE, "");
 		}
 	}
 	
-    void achievementViewDismissed()
-    {
+	void achievementViewDismissed() {
 		//dispatchHaxeEvent(ACHIEVEMENTS_VIEW_CLOSED);
 	}
-	
-	void leaderboardViewDismissed()
-    {
+
+	void leaderboardViewDismissed() {
 		//dispatchHaxeEvent(LEADERBOARD_VIEW_CLOSED);
 	}
 }

--- a/project/iphone/GameCenter.mm
+++ b/project/iphone/GameCenter.mm
@@ -169,7 +169,6 @@ namespace gamecenter
 					NSLog(@"  %@", [error localizedDescription]);
 					NSString* errorDescription = [error localizedDescription];
 					sendGameCenterEvent(AUTH_FAILURE, [errorDescription UTF8String]);
-					[errorDescription release];
 	            }
 	        })];
 	    }


### PR DESCRIPTION
* Fixed crash when you send the game to background and re-open it without being logged into GameCenter.
* Display login screen the first time you open the game (if not logged in).
* Avoid the return of unallocated strings.
* Clean the code (comments, spaces, tabs and indentation).